### PR TITLE
chore: remove private dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule FormDemo.MixProject do
       {:live_view_native_stylesheet, github: "liveview-native/live_view_native_stylesheet", branch: "main", override: true},
       {:live_view_native_swiftui, github: "liveview-native/liveview-client-swiftui", branch: "main"},
       {:live_view_native_jetpack, github: "liveview-native/liveview-client-jetpack", branch: "main"},
-      {:live_view_native_utility_classes, github: "liveview-native/live_view_native_utility_classes", branch: "main"}
+      #{:live_view_native_utility_classes, github: "liveview-native/live_view_native_utility_classes", branch: "main"}
     ]
   end
 


### PR DESCRIPTION
Removing  dependency that fails to install on `mix deps.get` app seems to work fine without